### PR TITLE
fix(deps): update containerd to v1.7.32 (alauda-3.18.6)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/Masterminds/vcs v1.13.3
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
-	github.com/containerd/containerd v1.7.31
+	github.com/containerd/containerd v1.7.32
 	github.com/cyphar/filepath-securejoin v0.5.1
 	github.com/distribution/distribution/v3 v3.1.1
 	github.com/evanphx/json-patch v5.9.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/chai2010/gettext-go v1.0.2 h1:1Lwwip6Q2QGsAdl/ZKPCwTe9fe0CjlUbqj5bFNS
 github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
 github.com/containerd/containerd v1.7.31 h1:jn3IMuTV4Bb1Uwb0MFPW2ASJAD3W1lh6QqqZHIZwDh4=
 github.com/containerd/containerd v1.7.31/go.mod h1:jdwD6s/BhV4XVJGrvtziNPVA+83n66TwptVaPKprq4E=
+github.com/containerd/containerd v1.7.32 h1:S54xuVcPxeLaYgaRABtpJ2VyVUVsy0IGf7qHBs+sbY8=
+github.com/containerd/containerd v1.7.32/go.mod h1:jdwD6s/BhV4XVJGrvtziNPVA+83n66TwptVaPKprq4E=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=


### PR DESCRIPTION
Updates github.com/containerd/containerd from v1.7.31 to v1.7.32, the fixed 1.7.x release for GHSA-fqw6-gf59-qr4w / CVE-2026-46680.\n\nThis replaces #90, which attempts a major-version move to v2.0.0 and currently fails to build because the code still imports github.com/containerd/containerd/remotes.\n\nLocal checks:\n- make test-source-headers\n- go test ./pkg/registry\n- KUBECONFIG=/tmp/nonexistent-helm-test-kubeconfig go test ./pkg/cli -run TestEnvSettings\n\nNote: make test-coverage was started locally, but failed on local Helm release fixture state and kube context before completing; the dependency-sensitive registry package passed.